### PR TITLE
响应镜像站变更以及支持SUSE系发行版

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,8 +21,8 @@ Install_Node() {
   echo "[→] cd /opt || exit"
   cd /opt || exit
 
-  echo "[↓] wget https://npm.taobao.org/mirrors/node/v14.19.1/node-v14.19.1-linux-${arch}.tar.gz"
-  wget https://npm.taobao.org/mirrors/node/v14.19.1/node-v14.19.1-linux-${arch}.tar.gz
+  echo "[↓] wget https://npmmirror.com/mirrors/node/v14.19.1/node-v14.19.1-linux-${arch}.tar.gz"
+  wget https://npmmirror.com/mirrors/node/v14.19.1/node-v14.19.1-linux-${arch}.tar.gz
 
   echo "[↑] tar -zxf node-v14.19.1-linux-${arch}.tar.gz"
   tar -zxf node-v14.19.1-linux-${arch}.tar.gz
@@ -72,8 +72,8 @@ Install_MCSManager() {
   echo "[→] cd daemon"
   cd daemon || exit
 
-  echo "[+] npm install --registry=https://registry.npm.taobao.org"
-  /usr/bin/env ${node_install_path}/bin/node ${node_install_path}/bin/npm install --registry=https://registry.npm.taobao.org
+  echo "[+] npm install --registry=https://registry.npmmirror.com"
+  /usr/bin/env ${node_install_path}/bin/node ${node_install_path}/bin/npm install --registry=https://registry.npmmirror.com
 
   echo "[←] cd .."
   cd ..
@@ -87,8 +87,8 @@ Install_MCSManager() {
   echo "[→] cd web"
   cd web || exit
 
-  echo "[+] npm install --registry=https://registry.npm.taobao.org"
-  /usr/bin/env ${node_install_path}/bin/node ${node_install_path}/bin/npm install --registry=https://registry.npm.taobao.org
+  echo "[+] npm install --registry=https://registry.npmmirror.com"
+  /usr/bin/env ${node_install_path}/bin/node ${node_install_path}/bin/npm install --registry=https://registry.npmmirror.com
 
   echo "=============== MCSManager ==============="
   echo " Daemon: ${mcsmanager_install_path}/daemon"

--- a/setup.sh
+++ b/setup.sh
@@ -211,7 +211,7 @@ echo "+----------------------------------------------------------------------
 +----------------------------------------------------------------------
 | Copyright © 2022 Suwings All rights reserved.
 +----------------------------------------------------------------------
-| Shell Install Script by Nuomiaa
+| Shell Install Script by Nuomiaa & CreeperKong
 +----------------------------------------------------------------------
 "
 
@@ -219,6 +219,7 @@ echo "[+] Installing dependent software... (git,tar)"
 yum install -y git tar
 apt install -y git tar
 pacman -Syu --noconfirm git tar
+zypper --non-interactive install git tar
 
 Install_Node
 Install_MCSManager


### PR DESCRIPTION
### 本次变更如下

1. 修改镜像源，为2022年7月淘宝镜像的变化做准备
2. 支持OPENSUSE和SUSE Enterprise Linux发行版（已测试）

### 参考
- https://npmmirror.com/
- https://zhuanlan.zhihu.com/p/465424728