### PR TITLE
简化仓库克隆 | Cloning Simplify

### DIFF
--- a/deb/pack/amd64/DEBIAN/preinst
+++ b/deb/pack/amd64/DEBIAN/preinst
@@ -212,13 +212,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho echo "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho echo "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho echo "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/deb/pack/arm/DEBIAN/preinst
+++ b/deb/pack/arm/DEBIAN/preinst
@@ -212,13 +212,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho echo "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho echo "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho echo "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/deb/pack/arm64/DEBIAN/preinst
+++ b/deb/pack/arm64/DEBIAN/preinst
@@ -212,13 +212,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho echo "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho echo "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho echo "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/deb/pack/i386/DEBIAN/preinst
+++ b/deb/pack/i386/DEBIAN/preinst
@@ -212,13 +212,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho echo "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho echo "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho echo "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/deb/pack/ppc64le/DEBIAN/preinst
+++ b/deb/pack/ppc64le/DEBIAN/preinst
@@ -212,13 +212,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho echo "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho echo "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho echo "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/deb/pack/s390x/DEBIAN/preinst
+++ b/deb/pack/s390x/DEBIAN/preinst
@@ -212,13 +212,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho echo "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho echo "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho echo "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/deb/src/DEBIAN/preinst.sh
+++ b/deb/src/DEBIAN/preinst.sh
@@ -196,13 +196,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho cyan "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho cyan "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho cyan "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/deb_setup.sh
+++ b/deb_setup.sh
@@ -260,13 +260,11 @@ Install() {
 
     # Download MCSM Daemon
     LEcho cyan "[↓] 正在下载 MCSManager Daemon..." "[↓] Downloading MCSManager Daemon..."
-    git clone --single-branch -b master --depth 1 ${daemonCloneURL}
-    mv -f MCSManager-Daemon-Production daemon
+    git clone --single-branch -b master --depth 1 ${daemonCloneURL} daemon
 
     # Download MCSM Web
     LEcho cyan "[↓] 正在下载 MCSManager Web..." "[↓] Downloading MCSManager Web..."
-    git clone --single-branch -b master --depth 1 ${webCloneURL}
-    mv -f MCSManager-Web-Production web
+    git clone --single-branch -b master --depth 1 ${webCloneURL} web
 
     # Install MCSM Daemon
     LEcho cyan "[+] 正在安装 MCSManager Daemon..." "[+] Installing MCSManager Daemon..."

--- a/setup.sh
+++ b/setup.sh
@@ -113,10 +113,7 @@ Install_MCSManager() {
     then echo_cyan "[↓] Git 克隆 MCSManager-Daemon..."
     else echo_cyan "[↓] Git clone MCSManager-Daemon..."
   fi
-  git clone --single-branch -b master --depth 1 https://gitee.com/mcsmanager/MCSManager-Daemon-Production.git
-
-  # echo "[-] mv MCSManager-Daemon-Production daemon"
-  mv MCSManager-Daemon-Production daemon
+  git clone --single-branch -b master --depth 1 https://gitee.com/mcsmanager/MCSManager-Daemon-Production.git daemon
 
   # echo "[→] cd daemon"
   cd daemon || exit
@@ -134,10 +131,7 @@ Install_MCSManager() {
     then echo_cyan "[↓] Git 克隆 MCSManager-Web..."
     else echo_cyan "[↓] Git clone MCSManager-Web..."
   fi
-  git clone --single-branch -b master --depth 1 https://gitee.com/mcsmanager/MCSManager-Web-Production.git
-
-  # echo "[-] mv MCSManager-Web-Production web"
-  mv MCSManager-Web-Production web
+  git clone --single-branch -b master --depth 1 https://gitee.com/mcsmanager/MCSManager-Web-Production.git web
 
   # echo "[→] cd web"
   cd web || exit

--- a/setup_en.sh
+++ b/setup_en.sh
@@ -84,10 +84,7 @@ Install_MCSManager() {
   cd ${mcsmanager_install_path} || exit
 
   echo_cyan "[↓] Git clone MCSManager-Daemon..."
-  git clone --single-branch -b master --depth 1 https://github.com/MCSManager/MCSManager-Daemon-Production.git
-
-  # echo "[-] mv MCSManager-Daemon-Production daemon"
-  mv MCSManager-Daemon-Production daemon
+  git clone --single-branch -b master --depth 1 https://github.com/MCSManager/MCSManager-Daemon-Production.git daemon
 
   # echo "[→] cd daemon"
   cd daemon || exit
@@ -99,10 +96,7 @@ Install_MCSManager() {
   cd ..
 
   echo_cyan "[↓] Git clone MCSManager-Web..."
-  git clone --single-branch -b master --depth 1 https://github.com/MCSManager/MCSManager-Web-Production.git
-
-  # echo "[-] mv MCSManager-Web-Production web"
-  mv MCSManager-Web-Production web
+  git clone --single-branch -b master --depth 1 https://github.com/MCSManager/MCSManager-Web-Production.git web
 
   # echo "[→] cd web"
   cd web || exit


### PR DESCRIPTION
Git 的 clone 指令支持使用`git clone <repo> <directory>`
因此不再需要额外的文件夹重命名

<s>话说这个有必要特地交一个PR吗</s>