### PR TITLE
Fix "sudo is needed to run this command" issue when install on openSUSE(SUSE Linux)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -219,7 +219,7 @@ echo_cyan_n "[+] Installing dependent software(git,tar)... "
 if [ -x "$(command -v yum)" ]; then yum install -y git tar > error;
 elif [ -x "$(command -v apt-get)" ]; then apt-get install -y git tar > error;
 elif [ -x "$(command -v pacman)" ]; then pacman -Syu --noconfirm git tar > error;
-elif [ -x "$(command -v zypper)" ]; then zypper --non-interactive install git tar > error;
+elif [ -x "$(command -v zypper)" ]; then sudo zypper --non-interactive install git tar > error;
 fi
 
 # Determine whether the relevant software is installed successfully

--- a/setup_cn.sh
+++ b/setup_cn.sh
@@ -248,7 +248,7 @@ echo_cyan_n "[+] Installing dependent software(git,tar)... "
 if [ -x "$(command -v yum)" ]; then yum install -y git tar > error;
 elif [ -x "$(command -v apt-get)" ]; then apt-get install -y git tar > error;
 elif [ -x "$(command -v pacman)" ]; then pacman -Syu --noconfirm git tar > error;
-elif [ -x "$(command -v zypper)" ]; then zypper --non-interactive install git tar > error;
+elif [ -x "$(command -v zypper)" ]; then sudo zypper --non-interactive install git tar > error;
 fi
 
 # Determine whether the relevant software is installed successfully

--- a/setup_en.sh
+++ b/setup_en.sh
@@ -219,7 +219,7 @@ echo_cyan_n "[+] Installing dependent software(git,tar)... "
 if [ -x "$(command -v yum)" ]; then yum install -y git tar > error;
 elif [ -x "$(command -v apt-get)" ]; then apt-get install -y git tar > error;
 elif [ -x "$(command -v pacman)" ]; then pacman -Syu --noconfirm git tar > error;
-elif [ -x "$(command -v zypper)" ]; then zypper --non-interactive install git tar > error;
+elif [ -x "$(command -v zypper)" ]; then sudo zypper --non-interactive install git tar > error;
 fi
 
 # Determine whether the relevant software is installed successfully


### PR DESCRIPTION
Under the openSUSE(SUSE Linux) security profile. sudo is needed to run binarys with specific parameter in "/usr/sbin" if the user isn't the real "root" user whether the script have root permission by user earlier or not.