### PR TITLE
Add an automated deployment script for macOS

### DIFF
--- a/setup_macOS.sh
+++ b/setup_macOS.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+# 获取脚本所在的目录作为安装目录
+# 使用 dirname "$0" 获取脚本路径，然后 cd 到该目录并打印当前路径 (pwd -P 处理符号链接)
+# 使用 || exit 表示如果 cd 失败就退出
+INSTALL_DIR="$(cd "$(dirname "$0")" || exit; pwd -P)"
+MCSM_DIR="$INSTALL_DIR/mcsmanager" # MCSManager 文件解压后的目录
+
+echo "=================================================="
+echo "  MCSManager 安装脚本 (macOS)"
+echo "=================================================="
+echo "安装目录: $INSTALL_DIR"
+echo "注意：需要 Homebrew 和 Node.js 已安装。"
+echo "=================================================="
+
+# --- 检查必要命令 ---
+echo "检查必要命令 (brew, node, npm, curl, tar, pm2)..."
+if ! command -v brew &> /dev/null; then
+    echo "错误: Homebrew 未找到。请先安装 Homebrew。"
+    exit 1
+fi
+if ! command -v node &> /dev/null; then
+    echo "错误: Node.js 未找到。请使用 'brew install node' 安装。"
+    exit 1
+fi
+if ! command -v npm &> /dev/null; then
+    echo "错误: npm 未找到。请确保 Node.js 安装正确。"
+    exit 1
+fi
+if ! command -v curl &> /dev/null; then
+    echo "错误: curl 未找到。"
+    exit 1
+fi
+if ! command -v tar &> /dev/null; then
+    echo "错误: tar 未找到。"
+    exit 1
+fi
+
+# 检查 PM2 是否全局安装，如果没有则提示用户或尝试安装
+if ! command -v pm2 &> /dev/null; then
+    echo "PM2 未找到。尝试全局安装 PM2..."
+    npm install -g pm2
+    if ! command -v pm2 &> /dev/null; then
+        echo "错误: PM2 安装失败。请手动运行 'npm install -g pm2'。"
+        exit 1
+    fi
+    echo "PM2 安装成功。"
+else
+    echo "PM2 已安装。"
+fi
+echo "必要命令检查通过。"
+
+# --- 提供安装选项 ---
+echo "请选择安装模式:"
+echo "1) 安装 Web 面板 + 节点 (Daemon) (推荐)"
+echo "2) 只安装节点 (Daemon)"
+read -p "请输入选项 (1 或 2): " choice
+
+# 验证用户输入
+if [[ "$choice" != "1" && "$choice" != "2" ]]; then
+    echo "无效的输入。请重新运行脚本并选择 1 或 2。"
+    exit 1
+fi
+
+# --- 创建安装目录 (脚本所在目录已存在，但需要确保是可写) ---
+echo "使用安装目录: $INSTALL_DIR"
+if [ ! -w "$INSTALL_DIR" ]; then
+    echo "错误: 脚本所在目录 $INSTALL_DIR 不可写。请检查权限。"
+    exit 1
+fi
+echo "目录权限检查通过。"
+
+# --- 下载 MCSManager Release ---
+# 使用 Linux 版本，因为 Node.js 部分是跨平台的，且 release 包同时包含 web 和 daemon
+MCSM_TAR_URL="https://github.com/MCSManager/MCSManager/releases/latest/download/mcsmanager_linux_release.tar.gz"
+MCSM_TAR_FILE="$INSTALL_DIR/mcsmanager_linux_release.tar.gz"
+
+echo "下载 MCSManager Release ($MCSM_TAR_URL) 到 $MCSM_TAR_FILE"
+# 使用 curl 下载，-L 跟随重定向，-o 指定输出文件，-f 在 HTTP 错误时退出
+curl -L -f "$MCSM_TAR_URL" -o "$MCSM_TAR_FILE"
+if [ $? -ne 0 ]; then
+    echo "错误: 下载失败。请检查网络连接或 URL。"
+    exit 1
+fi
+echo "下载成功。"
+
+# --- 解压 MCSManager Release ---
+echo "解压 $MCSM_TAR_FILE 到 $INSTALL_DIR"
+# -C 指定解压目录
+tar -zxf "$MCSM_TAR_FILE" -C "$INSTALL_DIR"
+if [ $? -ne 0 ]; then
+    echo "错误: 解压失败。"
+    # 尝试删除可能不完整的目录
+    rm -rf "$MCSM_DIR"
+    exit 1
+fi
+
+# 检查解压是否成功创建了 mcsmanager 目录
+if [ ! -d "$MCSM_DIR" ]; then
+    echo "错误: 解压失败。未找到目录 $MCSM_DIR。"
+    exit 1
+fi
+echo "解压成功。"
+
+# 清理下载的压缩包
+echo "移除下载的压缩包: $MCSM_TAR_FILE"
+rm "$MCSM_TAR_FILE"
+
+# --- 进入 MCSManager 目录并安装依赖 ---
+echo "切换到目录: $MCSM_DIR"
+cd "$MCSM_DIR"
+if [ $? -ne 0 ]; then
+    echo "错误: 无法切换到目录 $MCSM_DIR。"
+    exit 1
+fi
+
+echo "运行 ./install.sh 安装依赖..."
+# 使用 bash 确保脚本正确执行
+bash ./install.sh
+if [ $? -ne 0 ]; then
+    echo "错误: ./install.sh 运行失败。请检查输出信息。"
+    exit 1
+fi
+echo "依赖安装步骤完成。"
+
+# --- 使用 PM2 启动 MCSManager 进程并配置自启动 ---
+echo "使用 PM2 启动 MCSManager 进程..."
+
+# 停止并删除旧的 PM2 进程（如果存在）
+echo "停止并删除旧的 PM2 进程 (如果存在)..."
+pm2 stop MCSManager-Daemon &> /dev/null
+pm2 delete MCSManager-Daemon &> /dev/null
+pm2 stop MCSManager-Web &> /dev/null
+pm2 delete MCSManager-Web &> /dev/null
+sleep 1 # 等待片刻确保进程停止
+
+# 启动 Daemon
+echo "启动 MCSManager Daemon..."
+pm2 start ./start-daemon.sh --name "MCSManager-Daemon" --output "$INSTALL_DIR/daemon_output.log" --error "$INSTALL_DIR/daemon_error.log"
+sleep 3 # 等待片刻让 PM2 启动进程
+if ! pm2 status | grep -q "MCSManager-Daemon"; then
+    echo "错误: PM2 未能成功启动 MCSManager-Daemon。"
+    pm2 logs MCSManager-Daemon
+    exit 1
+fi
+echo "MCSManager Daemon 已通过 PM2 启动。"
+echo "查看 Daemon 状态: pm2 status MCSManager-Daemon"
+echo "查看 Daemon 日志: pm2 logs MCSManager-Daemon"
+echo "Daemon 默认监听端口: 24444"
+
+
+# 如果选择安装 Web 面板
+if [ "$choice" == "1" ]; then
+    echo ""
+    echo "启动 MCSManager Web 面板..."
+    pm2 start ./start-web.sh --name "MCSManager-Web" --output "$INSTALL_DIR/web_output.log" --error "$INSTALL_DIR/web_error.log"
+    sleep 3 # 等待片刻让 PM2 启动进程
+    if ! pm2 status | grep -q "MCSManager-Web"; then
+        echo "错误: PM2 未能成功启动 MCSManager-Web。"
+        pm2 logs MCSManager-Web
+        # 注意：这里不退出，因为 Daemon 可能已经启动成功
+        echo "请手动检查 MCSManager-Web 的问题。"
+    else
+        echo "MCSManager Web 面板已通过 PM2 启动。"
+        echo "查看 Web 状态: pm2 status MCSManager-Web"
+        echo "查看 Web 日志: pm2 logs MCSManager-Web"
+        echo "Web 默认监听端口: 23333"
+    fi
+fi
+
+echo ""
+echo "配置 PM2 自启动 (使用 launchd)..."
+# 这个命令会生成一个 launchd 配置文件，并通常会输出一条需要用户手动运行的命令
+# 运行一次即可，它配置的是 PM2 daemon 本身，而不是 MCSM 进程
+pm2 startup launchd
+
+echo ""
+echo "=================================================="
+if [ "$choice" == "1" ]; then
+    echo "       MCSManager Web 面板 + 节点 安装完成！"
+else
+    echo "       MCSManager 节点 (Daemon) 安装完成！"
+fi
+echo "=================================================="
+echo "安装目录: $INSTALL_DIR"
+echo ""
+
+echo "--- PM2 控制命令参考 ---"
+echo "查看所有 MCSManager 进程状态:"
+echo "  pm2 status"
+echo ""
+echo "--- Daemon (节点) ---"
+echo "进程名: MCSManager-Daemon"
+echo "日志文件: $INSTALL_DIR/daemon_output.log, $INSTALL_DIR/daemon_error.log"
+echo "启动 Daemon: pm2 start MCSManager-Daemon"
+echo "停止 Daemon: pm2 stop MCSManager-Daemon"
+echo "重启 Daemon: pm2 restart MCSManager-Daemon"
+echo "删除 Daemon (从 PM2 列表移除): pm2 delete MCSManager-Daemon"
+echo "查看 Daemon 日志: pm2 logs MCSManager-Daemon"
+echo "查看 Daemon 实时日志: pm2 logs MCSManager-Daemon --follow"
+echo ""
+
+if [ "$choice" == "1" ]; then
+    echo "--- Web 面板 ---"
+    echo "进程名: MCSManager-Web"
+    echo "日志文件: $INSTALL_DIR/web_output.log, $INSTALL_DIR/web_error.log"
+    echo "启动 Web: pm2 start MCSManager-Web"
+    echo "停止 Web: pm2 stop MCSManager-Web"
+    echo "重启 Web: pm2 restart MCSManager-Web"
+    echo "删除 Web (从 PM2 列表移除): pm2 delete MCSManager-Web"
+    echo "查看 Web 日志: pm2 logs MCSManager-Web"
+    echo "查看 Web 实时日志: pm2 logs MCSManager-Web --follow"
+    echo ""
+    echo "默认访问地址: http://localhost:23333"
+fi
+
+echo "--- 重要：完成自启动设置 ---"
+echo "请查找上面 'pm2 startup launchd' 命令的输出，它会显示一条需要您手动执行的命令，通常以 'sudo env PATH=...' 开头。"
+echo "请复制并粘贴该命令到终端中运行，以确保 PM2 Daemon 本身在系统重启后自动启动，从而管理 MCSManager 进程。"
+echo "示例 (请运行实际输出的命令):"
+echo "  sudo env PATH=\$PATH:/usr/local/bin /Users/youruser/.nvm/versions/node/vX.Y.Z/bin/pm2 startup launchd -u youruser --hp /Users/youruser"
+echo ""
+echo "=================================================="
+
+exit 0
+

--- a/setup_macOS.sh
+++ b/setup_macOS.sh
@@ -172,7 +172,7 @@ echo ""
 echo "Configuring PM2 startup (using launchd)..."
 startup_cmd=$(pm2 startup launchd | grep 'sudo' | sed 's/^.*\(sudo.*\)$/\1/')
 if [ -n "$startup_cmd" ]; then
-    echo "Executing PM2 startup command automatically..."
+    echo "Executing PM2 startup command automatically. Please enter your password below (not visible):"
     eval $startup_cmd
     if [ $? -eq 0 ]; then
         echo "PM2 startup configuration completed automatically."

--- a/setup_macOS.sh
+++ b/setup_macOS.sh
@@ -70,13 +70,14 @@ else
 fi
 echo "All dependencies checked and installed."
 
-echo "Web Panel + Node (Daemon) will be installed automatically (recommended)."
-read -p "Continue installation? (y/n): " confirm
-if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-    echo "Installation cancelled."
-    exit 0
+echo "Please select installation mode:"
+echo "1) Install Web Panel + Node (Daemon) (recommended)"
+echo "2) Install Node (Daemon) only"
+read -p "Enter your choice (1 or 2): " choice
+if [[ "$choice" != "1" && "$choice" != "2" ]]; then
+    echo "Invalid input. Please rerun the script and select 1 or 2."
+    exit 1
 fi
-choice="1"
 
 echo "Using install directory: $INSTALL_DIR"
 if [ ! -w "$INSTALL_DIR" ]; then
@@ -198,47 +199,47 @@ GLOBAL_JSON="$MCSM_DIR/daemon/data/Config/global.json"
 if [ -f "$GLOBAL_JSON" ]; then
     NODE_KEY=$(grep '"key"' "$GLOBAL_JSON" | head -n1 | sed 's/.*"key": *"\([^"]*\)".*/\1/')
     if [ -n "$NODE_KEY" ]; then
-        echo "请及时复制以下远程节点密钥，用于连接节点："
-        echo "节点 Key: $NODE_KEY"
+        echo "Please copy the following remote node key for connecting this node:"
+        echo "Node Key: $NODE_KEY"
     else
-        echo "未能自动获取节点 Key，请手动查看 $GLOBAL_JSON"
+        echo "Failed to automatically get node key, please check $GLOBAL_JSON manually."
     fi
 else
-    echo "未找到 $GLOBAL_JSON，无法获取节点 Key。"
+    echo "File $GLOBAL_JSON not found, unable to get node key."
 fi
 
 echo ""
-echo "--- PM2 控制命令参考 ---"
-echo "查看所有 MCSManager 进程状态:"
+echo "--- PM2 Command Reference ---"
+echo "Check all MCSManager process status:"
 echo "  pm2 status"
 echo ""
-echo "--- Daemon (节点) ---"
-echo "进程名: MCSManager-Daemon"
-echo "日志文件: $MCSM_DIR/daemon_output.log, $MCSM_DIR/daemon_error.log"
-echo "启动 Daemon: pm2 start MCSManager-Daemon"
-echo "停止 Daemon: pm2 stop MCSManager-Daemon"
-echo "重启 Daemon: pm2 restart MCSManager-Daemon"
-echo "删除 Daemon (从 PM2 列表移除): pm2 delete MCSManager-Daemon"
-echo "查看 Daemon 日志: pm2 logs MCSManager-Daemon"
-echo "查看 Daemon 实时日志: pm2 logs MCSManager-Daemon --follow"
+echo "--- Daemon (Node) ---"
+echo "Process name: MCSManager-Daemon"
+echo "Log files: $MCSM_DIR/daemon_output.log, $MCSM_DIR/daemon_error.log"
+echo "Start Daemon: pm2 start MCSManager-Daemon"
+echo "Stop Daemon: pm2 stop MCSManager-Daemon"
+echo "Restart Daemon: pm2 restart MCSManager-Daemon"
+echo "Delete Daemon (remove from PM2): pm2 delete MCSManager-Daemon"
+echo "View Daemon logs: pm2 logs MCSManager-Daemon"
+echo "View Daemon live logs: pm2 logs MCSManager-Daemon --follow"
 echo ""
 
 if [ "$choice" == "1" ]; then
-    echo "--- Web 面板 ---"
-    echo "进程名: MCSManager-Web"
-    echo "日志文件: $MCSM_DIR/web_output.log, $MCSM_DIR/web_error.log"
-    echo "启动 Web: pm2 start MCSManager-Web"
-    echo "停止 Web: pm2 stop MCSManager-Web"
-    echo "重启 Web: pm2 restart MCSManager-Web"
-    echo "删除 Web (从 PM2 列表移除): pm2 delete MCSManager-Web"
-    echo "查看 Web 日志: pm2 logs MCSManager-Web"
-    echo "查看 Web 实时日志: pm2 logs MCSManager-Web --follow"
+    echo "--- Web Panel ---"
+    echo "Process name: MCSManager-Web"
+    echo "Log files: $MCSM_DIR/web_output.log, $MCSM_DIR/web_error.log"
+    echo "Start Web: pm2 start MCSManager-Web"
+    echo "Stop Web: pm2 stop MCSManager-Web"
+    echo "Restart Web: pm2 restart MCSManager-Web"
+    echo "Delete Web (remove from PM2): pm2 delete MCSManager-Web"
+    echo "View Web logs: pm2 logs MCSManager-Web"
+    echo "View Web live logs: pm2 logs MCSManager-Web --follow"
     echo ""
-    echo "默认访问地址: http://localhost:23333"
+    echo "Default access: http://localhost:23333"
 fi
 
-echo "--- 重要：完成自启动设置 ---"
-echo "PM2 自启动配置已自动尝试执行。若有报错，请参考上方命令手动执行。"
+echo "--- IMPORTANT: Complete PM2 Startup Setup ---"
+echo "PM2 startup configuration has been attempted automatically. If there are errors, please refer to the command above and run it manually."
 echo "=================================================="
 
 exit 0

--- a/setup_macOS_cn.sh
+++ b/setup_macOS_cn.sh
@@ -4,194 +4,194 @@ INSTALL_DIR="$(cd "$(dirname "$0")" || exit; pwd -P)"
 MCSM_DIR="$INSTALL_DIR/mcsmanager"
 
 echo "=================================================="
-echo "  MCSManager Installation Script (macOS)"
+echo "  MCSManager 安装脚本 (macOS)"
 echo "=================================================="
-echo "Install directory: $INSTALL_DIR"
-echo "Note: Homebrew and Node.js are required."
+echo "安装目录: $INSTALL_DIR"
+echo "注意：需要 Homebrew 和 Node.js 已安装。"
 echo "=================================================="
 
-echo "Automatically checking and installing required dependencies (brew, node, npm, curl, tar, pm2)..."
+echo "将自动检测并安装所需依赖 (brew, node, npm, curl, tar, pm2)..."
 
 if ! command -v brew &> /dev/null; then
-    echo "Homebrew not found, installing Homebrew..."
+    echo "未检测到 Homebrew，正在自动安装 Homebrew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     if ! command -v brew &> /dev/null; then
-        echo "Error: Homebrew installation failed."
+        echo "错误: Homebrew 安装失败。"
         exit 1
     fi
 fi
 
 if ! command -v node &> /dev/null; then
-    echo "Node.js not found, installing Node.js via Homebrew..."
+    echo "未检测到 Node.js，正在通过 Homebrew 安装 Node.js..."
     brew install node
     if ! command -v node &> /dev/null; then
-        echo "Error: Node.js installation failed."
+        echo "错误: Node.js 安装失败。"
         exit 1
     fi
 fi
 
 if ! command -v npm &> /dev/null; then
-    echo "npm not found, reinstalling Node.js via Homebrew..."
+    echo "未检测到 npm，正在通过 Homebrew 重新安装 Node.js..."
     brew install node
     if ! command -v npm &> /dev/null; then
-        echo "Error: npm installation failed."
+        echo "错误: npm 安装失败。"
         exit 1
     fi
 fi
 
 if ! command -v curl &> /dev/null; then
-    echo "curl not found, installing curl via Homebrew..."
+    echo "未检测到 curl，正在通过 Homebrew 安装 curl..."
     brew install curl
     if ! command -v curl &> /dev/null; then
-        echo "Error: curl installation failed."
+        echo "错误: curl 安装失败。"
         exit 1
     fi
 fi
 
 if ! command -v tar &> /dev/null; then
-    echo "tar not found, installing tar via Homebrew..."
+    echo "未检测到 tar，正在通过 Homebrew 安装 tar..."
     brew install tar
     if ! command -v tar &> /dev/null; then
-        echo "Error: tar installation failed."
+        echo "错误: tar 安装失败。"
         exit 1
     fi
 fi
 
 if ! command -v pm2 &> /dev/null; then
-    echo "PM2 not found, installing PM2 globally..."
+    echo "未检测到 PM2，正在全局安装 PM2..."
     npm install -g pm2
     if ! command -v pm2 &> /dev/null; then
-        echo "Error: PM2 installation failed. Please run 'npm install -g pm2' manually."
+        echo "错误: PM2 安装失败。请手动运行 'npm install -g pm2'。"
         exit 1
     fi
-    echo "PM2 installed successfully."
+    echo "PM2 安装成功。"
 else
-    echo "PM2 is already installed."
+    echo "PM2 已安装。"
 fi
-echo "All dependencies checked and installed."
+echo "所有依赖检测并安装完成。"
 
-echo "Web Panel + Node (Daemon) will be installed automatically (recommended)."
-read -p "Continue installation? (y/n): " confirm
+echo "将自动安装 Web 面板 + 节点 (Daemon) (推荐)"
+read -p "是否继续安装？(y/n): " confirm
 if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-    echo "Installation cancelled."
+    echo "已取消安装。"
     exit 0
 fi
 choice="1"
 
-echo "Using install directory: $INSTALL_DIR"
+echo "使用安装目录: $INSTALL_DIR"
 if [ ! -w "$INSTALL_DIR" ]; then
-    echo "Error: $INSTALL_DIR is not writable. Please check permissions."
+    echo "错误: 脚本所在目录 $INSTALL_DIR 不可写。请检查权限。"
     exit 1
 fi
-echo "Directory permission check passed."
+echo "目录权限检查通过。"
 
 MCSM_TAR_URL="https://github.com/MCSManager/MCSManager/releases/latest/download/mcsmanager_linux_release.tar.gz"
 MCSM_TAR_FILE="$INSTALL_DIR/mcsmanager_linux_release.tar.gz"
 
-echo "Downloading MCSManager Release ($MCSM_TAR_URL) to $MCSM_TAR_FILE"
+echo "下载 MCSManager Release ($MCSM_TAR_URL) 到 $MCSM_TAR_FILE"
 curl -L -f "$MCSM_TAR_URL" -o "$MCSM_TAR_FILE"
 if [ $? -ne 0 ]; then
-    echo "Error: Download failed. Please check your network or the URL."
+    echo "错误: 下载失败。请检查网络连接或 URL。"
     exit 1
 fi
-echo "Download successful."
+echo "下载成功。"
 
-echo "Extracting $MCSM_TAR_FILE to $INSTALL_DIR"
+echo "解压 $MCSM_TAR_FILE 到 $INSTALL_DIR"
 tar -zxf "$MCSM_TAR_FILE" -C "$INSTALL_DIR"
 if [ $? -ne 0 ]; then
-    echo "Error: Extraction failed."
+    echo "错误: 解压失败。"
     rm -rf "$MCSM_DIR"
     exit 1
 fi
 
 if [ ! -d "$MCSM_DIR" ]; then
-    echo "Error: Extraction failed. Directory $MCSM_DIR not found."
+    echo "错误: 解压失败。未找到目录 $MCSM_DIR。"
     exit 1
 fi
-echo "Extraction successful."
+echo "解压成功。"
 
-echo "Removing downloaded archive: $MCSM_TAR_FILE"
+echo "移除下载的压缩包: $MCSM_TAR_FILE"
 rm "$MCSM_TAR_FILE"
 
-echo "Changing to directory: $MCSM_DIR"
+echo "切换到目录: $MCSM_DIR"
 cd "$MCSM_DIR"
 if [ $? -ne 0 ]; then
-    echo "Error: Failed to change directory to $MCSM_DIR."
+    echo "错误: 无法切换到目录 $MCSM_DIR。"
     exit 1
 fi
 
-echo "Running ./install.sh to install dependencies..."
+echo "运行 ./install.sh 安装依赖..."
 bash ./install.sh
 if [ $? -ne 0 ]; then
-    echo "Error: ./install.sh failed. Please check the output."
+    echo "错误: ./install.sh 运行失败。请检查输出信息。"
     exit 1
 fi
-echo "Dependency installation completed."
+echo "依赖安装步骤完成。"
 
-echo "Starting MCSManager processes with PM2..."
+echo "使用 PM2 启动 MCSManager 进程..."
 
-echo "Stopping and deleting old PM2 processes (if any)..."
+echo "停止并删除旧的 PM2 进程 (如果存在)..."
 pm2 stop MCSManager-Daemon &> /dev/null
 pm2 delete MCSManager-Daemon &> /dev/null
 pm2 stop MCSManager-Web &> /dev/null
 pm2 delete MCSManager-Web &> /dev/null
 sleep 1
 
-echo "Starting MCSManager Daemon..."
+echo "启动 MCSManager Daemon..."
 pm2 start ./start-daemon.sh --name "MCSManager-Daemon" --output "$MCSM_DIR/daemon_output.log" --error "$MCSM_DIR/daemon_error.log"
 sleep 3
 if ! pm2 status | grep -q "MCSManager-Daemon"; then
-    echo "Error: PM2 failed to start MCSManager-Daemon."
+    echo "错误: PM2 未能成功启动 MCSManager-Daemon。"
     pm2 logs MCSManager-Daemon
     exit 1
 fi
-echo "MCSManager Daemon started with PM2."
-echo "Check Daemon status: pm2 status MCSManager-Daemon"
-echo "Check Daemon logs: pm2 logs MCSManager-Daemon"
-echo "Daemon default port: 24444"
+echo "MCSManager Daemon 已通过 PM2 启动。"
+echo "查看 Daemon 状态: pm2 status MCSManager-Daemon"
+echo "查看 Daemon 日志: pm2 logs MCSManager-Daemon"
+echo "Daemon 默认监听端口: 24444"
 
 if [ "$choice" == "1" ]; then
     echo ""
-    echo "Starting MCSManager Web Panel..."
+    echo "启动 MCSManager Web 面板..."
     pm2 start ./start-web.sh --name "MCSManager-Web" --output "$MCSM_DIR/web_output.log" --error "$MCSM_DIR/web_error.log"
     sleep 3
     if ! pm2 status | grep -q "MCSManager-Web"; then
-        echo "Error: PM2 failed to start MCSManager-Web."
+        echo "错误: PM2 未能成功启动 MCSManager-Web。"
         pm2 logs MCSManager-Web
-        echo "Please check the MCSManager-Web issue manually."
+        echo "请手动检查 MCSManager-Web 的问题。"
     else
-        echo "MCSManager Web Panel started with PM2."
-        echo "Check Web status: pm2 status MCSManager-Web"
-        echo "Check Web logs: pm2 logs MCSManager-Web"
-        echo "Web default port: 23333"
+        echo "MCSManager Web 面板已通过 PM2 启动。"
+        echo "查看 Web 状态: pm2 status MCSManager-Web"
+        echo "查看 Web 日志: pm2 logs MCSManager-Web"
+        echo "Web 默认监听端口: 23333"
     fi
 fi
 
 echo ""
-echo "Configuring PM2 startup (using launchd)..."
+echo "配置 PM2 自启动 (使用 launchd)..."
 startup_cmd=$(pm2 startup launchd | grep 'sudo' | sed 's/^.*\(sudo.*\)$/\1/')
 if [ -n "$startup_cmd" ]; then
-    echo "Executing PM2 startup command automatically..."
+    echo "自动执行 PM2 自启动命令..."
     eval $startup_cmd
     if [ $? -eq 0 ]; then
-        echo "PM2 startup configuration completed automatically."
+        echo "PM2 自启动配置已自动完成。"
     else
-        echo "Failed to execute PM2 startup command automatically. Please run the following command manually:"
+        echo "自动执行 PM2 自启动命令失败，请手动执行以下命令："
         echo "  $startup_cmd"
     fi
 else
-    echo "Failed to get PM2 startup command automatically. Please run 'pm2 startup launchd' and follow the instructions."
+    echo "未能自动获取 PM2 自启动命令，请手动运行 'pm2 startup launchd' 并按提示操作。"
 fi
 
 echo ""
 echo "=================================================="
 if [ "$choice" == "1" ]; then
-    echo "       MCSManager Web Panel + Node installation completed!"
+    echo "       MCSManager Web 面板 + 节点 安装完成！"
 else
-    echo "       MCSManager Node (Daemon) installation completed!"
+    echo "       MCSManager 节点 (Daemon) 安装完成！"
 fi
 echo "=================================================="
-echo "Install directory: $INSTALL_DIR"
+echo "安装目录: $INSTALL_DIR"
 echo ""
 
 GLOBAL_JSON="$MCSM_DIR/daemon/data/Config/global.json"

--- a/setup_macOS_cn.sh
+++ b/setup_macOS_cn.sh
@@ -70,13 +70,14 @@ else
 fi
 echo "所有依赖检测并安装完成。"
 
-echo "将自动安装 Web 面板 + 节点 (Daemon) (推荐)"
-read -p "是否继续安装？(y/n): " confirm
-if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-    echo "已取消安装。"
-    exit 0
+echo "请选择安装模式："
+echo "1) 安装 Web 面板 + 节点 (Daemon) (推荐)"
+echo "2) 只安装节点 (Daemon)"
+read -p "请输入选项 (1 或 2): " choice
+if [[ "$choice" != "1" && "$choice" != "2" ]]; then
+    echo "无效的输入。请重新运行脚本并选择 1 或 2。"
+    exit 1
 fi
-choice="1"
 
 echo "使用安装目录: $INSTALL_DIR"
 if [ ! -w "$INSTALL_DIR" ]; then

--- a/setup_macOS_cn.sh
+++ b/setup_macOS_cn.sh
@@ -172,7 +172,7 @@ echo ""
 echo "配置 PM2 自启动 (使用 launchd)..."
 startup_cmd=$(pm2 startup launchd | grep 'sudo' | sed 's/^.*\(sudo.*\)$/\1/')
 if [ -n "$startup_cmd" ]; then
-    echo "自动执行 PM2 自启动命令..."
+    echo "自动执行 PM2 自启动命令 请在下方输入密码(非明文)"
     eval $startup_cmd
     if [ $? -eq 0 ]; then
         echo "PM2 自启动配置已自动完成。"


### PR DESCRIPTION
Added a fully automated deployment script for both Chinese and English versions for macOS, one-click installation of environments such as brew, npm, pm2, and managed by pm2 to ensure self-startup.