### PR TITLE
feat: add Enshrouded Docker server template

### DIFF
--- a/market-v2.json
+++ b/market-v2.json
@@ -300,9 +300,6 @@
                     "changeWorkdir": false,
                     "workingDir": "/opt/enshrouded",
                     "env": [
-                        "SERVER_NAME=Enshrouded Server",
-                        "SERVER_SLOT_COUNT=16",
-                        "SERVER_QUERYPORT=15637",
                         "PUID=4711",
                         "PGID=4711",
                         "UPDATE_CRON=*/30 * * * *"

--- a/market-v2.json
+++ b/market-v2.json
@@ -263,6 +263,55 @@
             }
         },
         {
+            "title": "Enshrouded Dedicated Server",
+            "language": "en_us",
+            "platform": "Linux",
+            "description": "Run Enshrouded Dedicated Server with mornedhels/enshrouded-server and edit its server and gameplay settings from MCSManager.",
+            "image": "https://cdn.cloudflare.steamstatic.com/steam/apps/1203620/header.jpg",
+            "gameType": "Enshrouded",
+            "category": "Latest Version",
+            "runtime": "Linux (AMD64)",
+            "hardware": "6 CPU cores, RAM 16G+, SSD 30G+",
+            "size": "",
+            "targetLink": "",
+            "author": "MCSManager",
+            "tags": [
+                "Docker version"
+            ],
+            "setupInfo": {
+                "startCommand": "",
+                "stopCommand": "^C",
+                "updateCommand": "",
+                "ie": "utf8",
+                "oe": "utf8",
+                "type": "steam/enshrouded",
+                "tag": [
+                    "Enshrouded"
+                ],
+                "fileCode": "utf8",
+                "processType": "docker",
+                "runAs": "",
+                "docker": {
+                    "image": "mornedhels/enshrouded-server:latest",
+                    "updateCommandImage": "",
+                    "ports": [
+                        "{mcsm_port1}:15637/udp"
+                    ],
+                    "changeWorkdir": false,
+                    "workingDir": "/opt/enshrouded",
+                    "env": [
+                        "SERVER_NAME=Enshrouded Server",
+                        "SERVER_SLOT_COUNT=16",
+                        "SERVER_QUERYPORT=15637",
+                        "PUID=4711",
+                        "PGID=4711",
+                        "UPDATE_CRON=*/30 * * * *"
+                    ],
+                    "extraVolumes": []
+                }
+            }
+        },
+        {
             "title": "Project Zomboid",
             "title-zh": "僵尸毁灭工程",
             "language": "en_us",


### PR DESCRIPTION
## Summary
- add an Enshrouded dedicated-server marketplace template
- use `mornedhels/enshrouded-server:latest`
- expose the Steam query port over UDP
- mount the server workspace at `/opt/enshrouded`
- register the `steam/enshrouded` type for friendly configuration in MCSManager

## Reference
https://github.com/mornedhels/enshrouded-server

## Verification
- marketplace JSON parses successfully
- exactly one Enshrouded entry is present
- Docker image manifest resolves
- Steam artwork returns HTTP 200 with an image content type